### PR TITLE
adding package source and provider options

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -87,22 +87,24 @@
 # Copyright 2013 Network Systems Team - Harvard University
 #
 class splunk (
-  $service_ensure  = $::splunk::params::service_ensure,
-  $service_enable  = $::splunk::params::service_enable,
-  $index           = $::splunk::params::index,
-  $index_hash      = $::splunk::params::index_hash,
-  $indexandforward = 'False',
-  $localusers      = $::splunk::params::localusers,
-  $licenseserver   = undef,
-  $nagios_contacts = $::splunk::params::nagios_contacts,
-  $nagiosserver    = $::splunk::nagiosserver,
-  $output_hash     = $::splunk::params::output_hash,
-  $port            = $::splunk::params::port,
-  $proxyserver     = $::splunk::params::proxyserver,
-  $purge           = $::splunk::params::purge,
-  $splunkadmin     = $::splunk::params::splunkadmin,
-  $target_group    = $::splunk::params::target_group,
-  $type            = $::splunk::params::type
+  $service_ensure   = $::splunk::params::service_ensure,
+  $service_enable   = $::splunk::params::service_enable,
+  $index            = $::splunk::params::index,
+  $index_hash       = $::splunk::params::index_hash,
+  $indexandforward  = 'False',
+  $localusers       = $::splunk::params::localusers,
+  $licenseserver    = undef,
+  $nagios_contacts  = $::splunk::params::nagios_contacts,
+  $nagiosserver     = $::splunk::nagiosserver,
+  $output_hash      = $::splunk::params::output_hash,
+  $port             = $::splunk::params::port,
+  $proxyserver      = $::splunk::params::proxyserver,
+  $purge            = $::splunk::params::purge,
+  $splunkadmin      = $::splunk::params::splunkadmin,
+  $target_group     = $::splunk::params::target_group,
+  $type             = $::splunk::params::type,
+  $package_source   = undef,
+  $package_provider = undef,
 ) inherits splunk::params {
 
 # Added the preseed hack after getting the idea from very cool

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,16 +1,20 @@
 class splunk::install (
-  $license     = $::splunk::license,
-  $pkgname     = $::splunk::pkgname,
-  $splunkadmin = $::splunk::splunkadmin,
-  $localusers  = $::splunk::localusers,
-  $SPLUNKHOME  = $::splunk::SPLUNKHOME,
-  $type        = $::splunk::type,
-  $version     = $::splunk::version,
+  $license          = $::splunk::license,
+  $pkgname          = $::splunk::pkgname,
+  $splunkadmin      = $::splunk::splunkadmin,
+  $localusers       = $::splunk::localusers,
+  $SPLUNKHOME       = $::splunk::SPLUNKHOME,
+  $type             = $::splunk::type,
+  $version          = $::splunk::version,
+  $package_source   = $::splunk::package_source,
+  $package_provider = $::splunk::package_provider,
   ) {
 
   package { "${pkgname}":
     ensure   => $version,
-  } ->
+    provider => $package_provider,
+    source   => $package_source,
+  }->
 
   file { '/etc/init.d/splunk':
     ensure  => present,


### PR DESCRIPTION
The only reason for the numerous line changes was for puppet-lint styling.  Other than that, only 6 lines actually changed.

These options allow a person to not have to put the package in a repo but can instead use the .deb or .rpm package sources instead.
