### PR TITLE
Updating custom fact to support ruby 1.9 'find' behavior

### DIFF
--- a/lib/facter/splunk_version.rb
+++ b/lib/facter/splunk_version.rb
@@ -5,8 +5,10 @@ Facter.add(:splunk_version, :timeout => 10) do
     command = ''
     path = ['/opt/splunk/bin','/opt/splunkforwarder/bin']
     path.each do |directory|
-      Find.find(directory) do |file|
-        command << file if !File::directory?(file) and File.executable?(file) and file =~ /.*\/splunk$/
+      if File.directory?(directory)
+        Find.find(directory) do |file|
+          command << file if !File::directory?(file) and File.executable?(file) and file =~ /.*\/splunk$/
+        end
       end
     end
     if command != ''


### PR DESCRIPTION
The default behavior of the find method has changed in ruby 1.9 to throw an error if the path searched does not exist. This caused the custom fact to break in Puppet Enterprise.

This PR will ignore a path if it is not a valid directory and allow functionality in ruby 1.8.7 and 1.9.3.
