### PR TITLE
Pinning rspec-core version to '3.1.7'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
   gem 'rake',                    :require => false
+  gem 'rspec-core', '3.1.7',     :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint',             :require => false


### PR DESCRIPTION
This should address the issue that @robruma is seeing in
huit/puppet-splunk#52

This looks like we hit a similar issue to the puppetlabs/puppetlabs-apt
module

https://github.com/rspec/rspec-core/issues/1864