### PR TITLE
Do not include splunk::outputs incase of universal forwarder

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -148,17 +148,14 @@ class splunk (
   } else {
     class { 'splunk::install':
       notify => Class['splunk::service'],
-      before => Class['splunk::outputs'],
     }
     class { 'splunk::service': }
 
     case $type {
       'uf': {
-        class { 'splunk::outputs': }
         class { 'splunk::config::mgmt_port': }
     }
       'lwf': {
-        class { 'splunk::outputs': }
         class { 'splunk::config::lwf': }
         class { 'splunk::config::mgmt_port': }
         class { 'splunk::config::remove_uf': }


### PR DESCRIPTION
When using this module to install UF/LWF as a deploystation client, there's no need to create an example outputs.conf file, it is breaking the forwarder config.