### PR TITLE
Fixed invalid puppet variable $SPLUNKHOME

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ## Overview
 
 
-The Splunk module manages both Splunk servers and forwarders on RedHat, Debian, and Ubuntu. 
+The Splunk module manages both Splunk servers and forwarders on RedHat, Debian, and Ubuntu.
 
 ## Module Description
 
@@ -40,17 +40,17 @@ Splunk agents, and have a Splunk deployment server to manage the configurations.
 * This is a great place to stick any warnings.
 * Can be in list or paragraph form.
 * Installation of Splunk Packages
-* Managment of the service init script (/etc/init.d/splunk) 
+* Managment of the service init script (/etc/init.d/splunk)
 * Managment of configuration files under /opt/splunk
   * inputs.conf and outputs.conf
   * indexes.conf on indexers and search heads
 * listened-to ports for Heavy forwarders and indexers
 
 
-### Setup Requirements 
+### Setup Requirements
 
 If your running a version of Puppet that does not have pluginsync enabled, it should
-be enabled. 
+be enabled.
 
 Use of Hiera for passing parameters is *highly* encouraged!
 
@@ -63,7 +63,7 @@ By default behavior is to install a Universal Forwarder and configure the agent 
 forward events to one or many indexers. The below example will install and configure
 a universal forwarder to send events via port to an indexer at IP 1.2.3.4 listening on
 port 9997. target_group takes the form of a hash, with name as the name keyword for your
-indexer, and the IP as the value.  So a more real world example might be 
+indexer, and the IP as the value.  So a more real world example might be
 { 'datacenter1' => 'IP/DNS Enter' }
 
 ```Puppet
@@ -74,12 +74,12 @@ class { 'splunk':
 
 To Change the "type" of installation, for example from a Universal forward to a
 Light Weight Forwarder, you can pass the "type" paramter to the Splunk Class. It is
-worth noting that the module will attempt to cleanup after itself. So for example if 
+worth noting that the module will attempt to cleanup after itself. So for example if
 your default node definition installs the universal forwarder, and you place the node
 into a role that inludes the light weight forwarder type, the Splunk module will attempt
 to uninstall and clean up the universal forwarder from /opt/splunkforwarder before
 installing into /opt/splunk. This typically has little effect, but does cause the newly
-installed agent to reindex any inputs that were assigned to both types. 
+installed agent to reindex any inputs that were assigned to both types.
 
 ```Puppet
 class { 'splunk':
@@ -89,8 +89,8 @@ class { 'splunk':
 ```
 
 To install Splunk and configure Splunk TA's  you can use the splunk::ta::<type>
-defined types. In this example the Splunk Unix TA is installed from the 
-Puppet master and deployed from the ta files directory within the Splunk module. 
+defined types. In this example the Splunk Unix TA is installed from the
+Puppet master and deployed from the ta files directory within the Splunk module.
 
 ```Puppet
 class { 'splunk':
@@ -101,13 +101,13 @@ splunk::ta::files { 'Splunk_TA_nix': }
 
 ## Usage
 
-[Splunk Universal Forwarder](#splunk-universal-forwarder)  
-[Splunk Light Weight Forwarder](#splunk-light-weight-forwarder)  
-[Splunk Indexer](#splunk-indexer)  
-[Deployment Client](#configure-deployment-client)  
-[Inputs.conf](#splunkinputs)  
+[Splunk Universal Forwarder](#splunk-universal-forwarder)
+[Splunk Light Weight Forwarder](#splunk-light-weight-forwarder)
+[Splunk Indexer](#splunk-indexer)
+[Deployment Client](#configure-deployment-client)
+[Inputs.conf](#splunkinputs)
 [Outputs.conf](#splunkoutputs)
-[Props.conf](#splunkprops)  
+[Props.conf](#splunkprops)
 [Transforms.conf](#splunktransforms)
 [Server Ulimit](#splunkulimit)
 
@@ -208,7 +208,7 @@ If you have a Splunk Deployment Server set up, you can bind the Splunk instance
 running on your node to a deployment server with the deploymentclient sub class.
 Add this to your node.pp or site/<node type module>. In the below example we are managing
 A Light Weight Forwarder with foo.com on port 8089.  Please NOTE - Some basic aspects of
-the client are still under Puppet Control. 
+the client are still under Puppet Control.
 - Version
 - Admin PW
 - Type
@@ -226,10 +226,10 @@ class { 'splunk::deploymentclient':
   This is an optional sub-class which you can pass a nested hash into to create
   custom inputs for Heavy Fowarders, agents or indexers
 
-  By Default the file is created in $SPLUNKHOME/etc/system/local
+  By Default the file is created in $splunkhome/etc/system/local
 
 ```Puppet
-class { 'splunk::inputs': 
+class { 'splunk::inputs':
   input_hash   => { 'script://./bin/sshdChecker.sh' => {
                        disabled   => 'true',
                        index      => 'os',
@@ -250,13 +250,13 @@ class { 'splunk::inputs':
   This is an optional sub-class which you can pass a nested hash into to create
   custom props.conf
 
-  By Default the file is created in $SPLUNKHOME/etc/system/local
+  By Default the file is created in $splunkhome/etc/system/local
 
 ### splunk::transforms
   This is an optional sub-class which you can pass a nested hash into to create
   custom transforms
 
-  By Default the file is created in $SPLUNKHOME/etc/system/local
+  By Default the file is created in $splunkhome/etc/system/local
 
 ### splunk::ulimit
   splunk::ulimit takes two parameters, the name of the limit to change
@@ -285,11 +285,11 @@ with things. (We are working on automating this section!)
 
 ###RHEL/CentOS 5
 
-RHEL/CentOS 5 is fully supported and functional 
+RHEL/CentOS 5 is fully supported and functional
 
 ###RHEL/CentOS 6
 
-RHEL/CentOS 6 is fully supported and functional 
+RHEL/CentOS 6 is fully supported and functional
 
 ###RHEL/CentOS 7
 

--- a/files/ta/Splunk_TA_nix/appserver/modules/TA_Unix_FTR/TA_Unix_FTR.js
+++ b/files/ta/Splunk_TA_nix/appserver/modules/TA_Unix_FTR/TA_Unix_FTR.js
@@ -1,22 +1,22 @@
-// Copyright 2011 Splunk, Inc.                                      
+// Copyright 2011 Splunk, Inc.
 //
-//   Licensed under the Apache License, Version 2.0 (the "License");         
-//   you may not use this file except in compliance with the License.        
-//   You may obtain a copy of the License at                                 
-//                                                                           
-//       http://www.apache.org/licenses/LICENSE-2.0                          
-//                                                                           
-//   Unless required by applicable law or agreed to in writing, software     
-//   distributed under the License is distributed on an "AS IS" BASIS,       
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-//   See the License for the specific language governing permissions and     
-//   limitations under the License.    
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
 
 Splunk.namespace("Module");
 Splunk.Module.TA_Unix_FTR= $.klass(Splunk.Module, {
 
-    COLLISION_WARN: '<p class="popupText">The app "%s" is installed on this system.</p><p class="popupText">Splunk for Unix Technical Add-on and the "%s" app cannot exist together on the same Splunk instance.</p><p class="popupText">Please click on Manage Apps to disable the conflicting app, then remove "%s" from $SPLUNK_HOME/etc/apps and restart Splunk.</p>',
-    
+    COLLISION_WARN: '<p class="popupText">The app "%s" is installed on this system.</p><p class="popupText">Splunk for Unix Technical Add-on and the "%s" app cannot exist together on the same Splunk instance.</p><p class="popupText">Please click on Manage Apps to disable the conflicting app, then remove "%s" from $splunk_home/etc/apps and restart Splunk.</p>',
+
     initialize: function($super, container) {
         $super(container);
         this.logger = Splunk.Logger.getLogger("ta_unix_ftr.js");
@@ -37,12 +37,12 @@ Splunk.Module.TA_Unix_FTR= $.klass(Splunk.Module, {
                         label: _("Manage Apps"),
                         type: "primary",
                         callback: function(){
-                            Splunk.util.redirect_to('manager/' + Splunk.util.getCurrentApp() + '/apps/local');                                                    
+                            Splunk.util.redirect_to('manager/' + Splunk.util.getCurrentApp() + '/apps/local');
                         }.bind(this)
-                    }       
-                ]       
-           });      
-        } 
+                    }
+                ]
+           });
+        }
     }
 
 });

--- a/manifests/config/hwf.pp
+++ b/manifests/config/hwf.pp
@@ -1,15 +1,15 @@
 #Private Class to enable/disable HWF
 class splunk::config::hwf (
-  $SPLUNKHOME = $::splunk::SPLUNKHOME,
+  $splunkhome = $::splunk::splunkhome,
   $status  = 'enabled'
   ) {
-  file { "${SPLUNKHOME}/etc/apps/SplunkForwarder/local":
+  file { "${splunkhome}/etc/apps/SplunkForwarder/local":
     ensure  => 'directory',
     owner   => 'splunk',
     group   => 'splunk',
     require => Class['splunk::install'],
   }
-  file { "${SPLUNKHOME}/etc/apps/SplunkForwarder/local/app.conf":
+  file { "${splunkhome}/etc/apps/SplunkForwarder/local/app.conf":
     ensure  => file,
     owner   => 'splunk',
     group   => 'splunk',
@@ -18,7 +18,7 @@ class splunk::config::hwf (
   } ->
   ini_setting { 'Enable Splunk HWF':
     ensure  => present,
-    path    => "${SPLUNKHOME}/etc/apps/SplunkForwarder/local/app.conf",
+    path    => "${splunkhome}/etc/apps/SplunkForwarder/local/app.conf",
     section => 'install',
     setting => 'state',
     value   => $status,

--- a/manifests/config/license.pp
+++ b/manifests/config/license.pp
@@ -1,7 +1,7 @@
 #Private Class to Configure Splunk License Slave
 class splunk::config::license (
   $server     = undef,
-  $SPLUNKHOME = $::splunk::SPLUNKHOME
+  $splunkhome = $::splunk::splunkhome
   ) {
   if ( $server == 'self' ) {
     $uri = $server
@@ -11,7 +11,7 @@ class splunk::config::license (
   if ( $server ) {
     ini_setting { 'Configure Splunk License':
       ensure  => present,
-      path    => "${SPLUNKHOME}/etc/system/local/server.conf",
+      path    => "${splunkhome}/etc/system/local/server.conf",
       section => 'license',
       setting => 'master_uri',
       value   => $uri,

--- a/manifests/config/lwf.pp
+++ b/manifests/config/lwf.pp
@@ -1,15 +1,15 @@
 #Private Class to enable/disable LWF
 class splunk::config::lwf (
-  $SPLUNKHOME = $::splunk::SPLUNKHOME,
+  $splunkhome = $::splunk::splunkhome,
   $status  = 'enabled'
   ) {
-  file { "${SPLUNKHOME}/etc/apps/SplunkLightForwarder/local":
+  file { "${splunkhome}/etc/apps/SplunkLightForwarder/local":
     ensure  => 'directory',
     owner   => 'splunk',
     group   => 'splunk',
     require => Class['splunk::install'],
   }
-  file { "${SPLUNKHOME}/etc/apps/SplunkLightForwarder/local/app.conf":
+  file { "${splunkhome}/etc/apps/SplunkLightForwarder/local/app.conf":
     ensure  => file,
     owner   => 'splunk',
     group   => 'splunk',
@@ -18,7 +18,7 @@ class splunk::config::lwf (
   } ->
   ini_setting { 'Enable Splunk LWF':
     ensure  => present,
-    path    => "${SPLUNKHOME}/etc/apps/SplunkLightForwarder/local/app.conf",
+    path    => "${splunkhome}/etc/apps/SplunkLightForwarder/local/app.conf",
     section => 'install',
     setting => 'state',
     value   => $status,

--- a/manifests/config/mgmt_port.pp
+++ b/manifests/config/mgmt_port.pp
@@ -1,11 +1,11 @@
 #Private Class to enable/disable the Splunk Managment Port
 class splunk::config::mgmt_port (
   $disableDefaultPort = 'True',
-  $SPLUNKHOME         = $::splunk::SPLUNKHOME
+  $splunkhome         = $::splunk::splunkhome
   ) {
   ini_setting { 'Configure Management Port':
     ensure  => present,
-    path    => "${SPLUNKHOME}/etc/system/local/server.conf",
+    path    => "${splunkhome}/etc/system/local/server.conf",
     section => 'httpServer',
     setting => 'disableDefaultPort',
     value   => $disableDefaultPort,

--- a/manifests/config/uf.pp
+++ b/manifests/config/uf.pp
@@ -1,11 +1,11 @@
 #Private Class configure universal forwarders
 class splunk::config::uf (
-  $SPLUNKHOME = $::splunk::SPLUNKHOME,
+  $splunkhome = $::splunk::splunkhome,
   $status  = 'enabled'
   ) {
   ini_setting { 'Disable Management Port':
     ensure  => present,
-    path    => "${SPLUNKHOME}/etc/system/local/server.conf",
+    path    => "${splunkhome}/etc/system/local/server.conf",
     section => 'httpServer',
     setting => 'disableDefaultPort',
     value   => 'True',

--- a/manifests/deploymentclient.pp
+++ b/manifests/deploymentclient.pp
@@ -11,7 +11,7 @@
 #   targeturi => 'deploymentserver.splunk.mycompany.com:8089'
 #
 class splunk::deploymentclient (
-  $path              = "${::splunk::SPLUNKHOME}/etc/system/local",
+  $path              = "${::splunk::splunkhome}/etc/system/local",
   $targeturi         = undef
   ) {
   Class{ require => Class['splunk::install'] }

--- a/manifests/indexes.pp
+++ b/manifests/indexes.pp
@@ -19,7 +19,7 @@
 #  }
 #
 class splunk::indexes (
-  $path         = "${::splunk::SPLUNKHOME}/etc/system/local",
+  $path         = "${::splunk::splunkhome}/etc/system/local",
   $input_hash   = $::splunk::index_hash
   ) {
   # Validate hash

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -125,16 +125,16 @@ class splunk (
   case $type {
     'uf': {
       $pkgname    = 'splunkforwarder'
-      $SPLUNKHOME = '/opt/splunkforwarder'
+      $splunkhome = '/opt/splunkforwarder'
       $license    = undef
     }
     'hfw','lwf': {
-      $SPLUNKHOME = '/opt/splunk'
+      $splunkhome = '/opt/splunk'
       $pkgname    = 'splunk'
       $license    = 'puppet:///modules/splunk/noarch/opt/splunk/etc/splunk-forwarder.license'
     }
     default: {
-      $SPLUNKHOME = '/opt/splunk'
+      $splunkhome = '/opt/splunk'
       $pkgname    = 'splunk'
       $license    = undef
     }

--- a/manifests/inputs.pp
+++ b/manifests/inputs.pp
@@ -25,7 +25,7 @@
 #  }
 #
 class splunk::inputs (
-  $path         = "${::splunk::SPLUNKHOME}/etc/system/local",
+  $path         = "${::splunk::splunkhome}/etc/system/local",
   $input_hash   = { }
   ) {
   # Validate hash

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@ class splunk::install (
   $pkgname          = $::splunk::pkgname,
   $splunkadmin      = $::splunk::splunkadmin,
   $localusers       = $::splunk::localusers,
-  $SPLUNKHOME       = $::splunk::SPLUNKHOME,
+  $splunkhome       = $::splunk::splunkhome,
   $type             = $::splunk::type,
   $version          = $::splunk::version,
   $package_source   = $::splunk::package_source,
@@ -27,20 +27,20 @@ class splunk::install (
   # inifile
   ini_setting { 'Server Name':
     ensure  => present,
-    path    => "${SPLUNKHOME}/etc/system/local/server.conf",
+    path    => "${splunkhome}/etc/system/local/server.conf",
     section => 'general',
     setting => 'serverName',
     value   => $::fqdn,
   } ->
   ini_setting { 'SSL v3 only':
     ensure  => present,
-    path    => "${SPLUNKHOME}/etc/system/local/server.conf",
+    path    => "${splunkhome}/etc/system/local/server.conf",
     section => 'sslConfig',
     setting => 'supportSSLV3Only',
     value   => 'True',
   } ->
 
-  file { "${SPLUNKHOME}/etc/splunk.license":
+  file { "${splunkhome}/etc/splunk.license":
     ensure => present,
     mode   => '0644',
     owner  => 'splunk',
@@ -49,7 +49,7 @@ class splunk::install (
     source => $license,
   } ->
 
-  file { "${SPLUNKHOME}/etc/passwd":
+  file { "${splunkhome}/etc/passwd":
     ensure  => present,
     mode    => '0600',
     owner   => 'root',
@@ -60,7 +60,7 @@ class splunk::install (
 
   # recursively copy the contents of the auth dir
   # This is causing a restart on the second run. - TODO
-  file { "${SPLUNKHOME}/etc/auth":
+  file { "${splunkhome}/etc/auth":
       mode    => '0600',
       owner   => 'splunk',
       group   => 'splunk',

--- a/manifests/outputs.pp
+++ b/manifests/outputs.pp
@@ -30,7 +30,7 @@ class splunk::outputs (
   $indexandforward = $::splunk::indexandforward,
   $output_hash     = $::splunk::output_hash,
   $port            = $::splunk::port,
-  $path            = "${::splunk::SPLUNKHOME}/etc/system/local",
+  $path            = "${::splunk::splunkhome}/etc/system/local",
   $tcpout_disabled = false,
   $target_group    = $::splunk::target_group
   ) {

--- a/manifests/props.pp
+++ b/manifests/props.pp
@@ -25,7 +25,7 @@
 #  }
 #
 class splunk::props (
-  $path         = "${::splunk::SPLUNKHOME}/etc/system/local",
+  $path         = "${::splunk::splunkhome}/etc/system/local",
   $input_hash   = { }
   ) {
   # Validate hash

--- a/manifests/ta/files.pp
+++ b/manifests/ta/files.pp
@@ -24,11 +24,11 @@ define splunk::ta::files (
   $index      = $::splunk::index,
   $inputfile  = "splunk/${title}/inputs.conf.erb",
   $status     = 'enabled',
-  $SPLUNKHOME = $::splunk::SPLUNKHOME
+  $splunkhome = $::splunk::splunkhome
 ) {
   File { ignore => '*.py[oc]' }
 
-  file { "${SPLUNKHOME}/etc/apps/${title}":
+  file { "${splunkhome}/etc/apps/${title}":
     ensure  => present,
     owner   => 'splunk',
     group   => 'splunk',
@@ -38,10 +38,10 @@ define splunk::ta::files (
     require => Class['splunk::install'],
     notify  => Class['splunk::service'],
   } ->
-  file { "${SPLUNKHOME}/etc/apps/${title}/local":
+  file { "${splunkhome}/etc/apps/${title}/local":
     ensure => directory,
   } ->
-  file { "${SPLUNKHOME}/etc/apps/${title}/local/app.conf":
+  file { "${splunkhome}/etc/apps/${title}/local/app.conf":
     ensure  => file,
     owner   => 'splunk',
     group   => 'splunk',
@@ -49,7 +49,7 @@ define splunk::ta::files (
     require => Class['splunk::install'],
     notify  => Class['splunk::service'],
   } ->
-  file { "${SPLUNKHOME}/etc/apps/${title}/local/inputs.conf":
+  file { "${splunkhome}/etc/apps/${title}/local/inputs.conf":
     ensure  => present,
     owner   => 'splunk',
     group   => 'splunk',
@@ -59,7 +59,7 @@ define splunk::ta::files (
   } ->
   ini_setting { "Enable Splunk ${title} TA":
     ensure  => present,
-    path    => "${SPLUNKHOME}/etc/apps/${title}/local/app.conf",
+    path    => "${splunkhome}/etc/apps/${title}/local/app.conf",
     section => 'install',
     setting => 'state',
     value   => $status,

--- a/manifests/ta/package.pp
+++ b/manifests/ta/package.pp
@@ -39,16 +39,16 @@ define splunk::ta::package (
   $index      = $::splunk::index,
   $inputfile  = "splunk/${title}/inputs.conf.erb",
   $status     = 'enabled',
-  $SPLUNKHOME = $::splunk::SPLUNKHOME
+  $splunkhome = $::splunk::splunkhome
 ) {
   package { "splunk-${title}":
     require => Class['splunk::install'],
     notify  => Class['splunk::service'],
   } ->
-  file { "${SPLUNKHOME}/etc/apps/${title}/local":
+  file { "${splunkhome}/etc/apps/${title}/local":
     ensure => directory,
   } ->
-  file { "${SPLUNKHOME}/etc/apps/${title}/local/app.conf":
+  file { "${splunkhome}/etc/apps/${title}/local/app.conf":
     ensure  => file,
     owner   => 'splunk',
     group   => 'splunk',
@@ -56,7 +56,7 @@ define splunk::ta::package (
     require => Class['splunk::install'],
     notify  => Class['splunk::service'],
   } ->
-  file { "${SPLUNKHOME}/etc/apps/${title}/local/inputs.conf":
+  file { "${splunkhome}/etc/apps/${title}/local/inputs.conf":
     ensure  => present,
     owner   => 'splunk',
     group   => 'splunk',
@@ -66,7 +66,7 @@ define splunk::ta::package (
   } ->
   ini_setting { "Enable Splunk ${title} TA":
     ensure  => present,
-    path    => "${SPLUNKHOME}/etc/apps/${title}/local/app.conf",
+    path    => "${splunkhome}/etc/apps/${title}/local/app.conf",
     section => 'install',
     setting => 'state',
     value   => $status,

--- a/manifests/transforms.pp
+++ b/manifests/transforms.pp
@@ -25,7 +25,7 @@
 #  }
 #
 class splunk::transforms (
-  $path         = "${::splunk::SPLUNKHOME}/etc/system/local",
+  $path         = "${::splunk::splunkhome}/etc/system/local",
   $input_hash   = { }
   ) {
   # Validate hash


### PR DESCRIPTION
Example error:
`Error: Illegal variable name, The given name 'SPLUNKHOME' does not conform to the naming rule /^((::)?[a-z]w*)*((::)?[a-z_]w*)$/ at /etc/puppet/modules/splunk/manifests/init.pp:128:7`

**Note**: There are some superfluous changes where my editor stripped trailing whitespace, but the key changes are changing `$SPLUNKHOME` -> `$splunkhome`