### PR TITLE
Added support for setting replace property when creating ${splunkhome}/etc/passwd file

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,6 +119,7 @@ class splunk (
   $package_source    = undef,
   $package_provider  = undef,
   $version           = $::splunk::params::version,
+  $replace_passwd    = $::splunk::params::replace_passwd, 
 ) inherits splunk::params {
 
 # Added the preseed hack after getting the idea from very cool

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,6 +8,7 @@ class splunk::install (
   $version          = $::splunk::version,
   $package_source   = $::splunk::package_source,
   $package_provider = $::splunk::package_provider,
+  $replace_passwd   = $::splunk::replace_passwd
   ) {
 
   package { $pkgname:
@@ -51,6 +52,7 @@ class splunk::install (
 
   file { "${splunkhome}/etc/passwd":
     ensure  => present,
+    replace => $replace_passwd,
     mode    => '0600',
     owner   => 'root',
     group   => 'root',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,6 +13,7 @@ class splunk::params {
   $proxyserver       = undef
   $purge             = undef
   $version           = 'installed'
+  $replace_passwd    = 'no'
 
   if $::mode == maintenance {
     $service_ensure = 'stopped'

--- a/spec/classes/splunk_spec.rb
+++ b/spec/classes/splunk_spec.rb
@@ -3,52 +3,67 @@ require 'spec_helper'
 describe 'splunk', :type => :class do
   describe "on RedHat platform" do
     let(:facts) { { :osfamily => 'RedHat' } }
-
-    describe "Splunk class with no parameters, basic test" do
-      let(:params) { { } }
+    shared_examples "splunk_general" do
+      it {
+        should compile
+        should create_class('splunk')
+        should contain_class('splunk::outputs')
+        should contain_class('splunk::config::mgmt_port')
+        should contain_service('splunk').with(
+          'ensure' => 'running',
+          'enable' => 'true'
+        )
+      }
+    end
+    shared_examples "forwarder_general" do
+      include_examples "splunk_general" do
         it {
-          should compile
-          should create_class('splunk')
-          should contain_class('splunk::outputs')
-          should contain_class('splunk::config::mgmt_port')
           should contain_package('splunkforwarder')
-	  should contain_service('splunk').with(
-            'ensure' => 'running',
-            'enable' => 'true'
+          should contain_file('/opt/splunkforwarder/etc/passwd').with(
+            'replace' => 'no'
           )
+        }
+      end
+    end
+    describe "Splunk class with no parameters, basic test" do
+      include_examples "forwarder_general" do
+        let(:params) { { } }
+        it {
           should contain_file('/opt/splunkforwarder/etc/system/local/outputs.conf')
         }
+      end
     end
     describe "With type param set to 'lwf'" do
-      let(:params) { { :type => 'lwf' } }
+      include_examples "splunk_general" do
+        let(:params) { { :type => 'lwf' } }
         it {
-          should compile
-          should create_class('splunk')
-          should contain_class('splunk::outputs')
-          should contain_class('splunk::config::mgmt_port')
           should contain_class('splunk::config::lwf')
           should contain_class('splunk::config::remove_uf')
           should contain_package('splunk')
-	  should contain_service('splunk').with(
-            'ensure' => 'running',
-            'enable' => 'true'
+          should contain_file('/opt/splunk/etc/passwd').with(
+            'replace' => 'no'
           )
         }
+      end
     end
     describe "With configure_outputs set to false" do
-      let(:params) { { :configure_outputs => false } }
+      include_examples "forwarder_general" do
+        let(:params) { { :configure_outputs => false } }
         it {
-          should compile
-          should create_class('splunk')
-          should contain_class('splunk::outputs')
-          should contain_class('splunk::config::mgmt_port')
-          should contain_package('splunkforwarder')
           should_not contain_file('/opt/splunkforwarder/etc/system/local/outputs.conf')
-	  should contain_service('splunk').with(
-            'ensure' => 'running',
-            'enable' => 'true'
+        }
+      end
+    end
+    describe "With replace_passwd set to yes" do
+      include_examples "splunk_general" do
+        let(:params) { { :replace_passwd => 'yes' } }
+        it {
+          should contain_package('splunkforwarder')
+          should contain_file('/opt/splunkforwarder/etc/passwd').with(
+            'replace' => 'yes'
           )
         }
+      end
     end
   end
 end


### PR DESCRIPTION
This adds support for setting `replace` property when creating ${splunkhome}/etc/passwd file. The value of 'no' or 'false' (default) will prevent puppet from managing the passwd file if it already exists.

Reasons for needing the ability to set this property include scenarios where we may not specifically want to modify existing splunk user accounts (credentials), but still want to retain the ability to roll out other configuration changes via puppet.