### PR TITLE
bugfix/64 - puppet-lint check error

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,7 +119,7 @@ class splunk (
   $package_source    = undef,
   $package_provider  = undef,
   $version           = $::splunk::params::version,
-  $replace_passwd    = $::splunk::params::replace_passwd, 
+  $replace_passwd    = $::splunk::params::replace_passwd,
 ) inherits splunk::params {
 
 # Added the preseed hack after getting the idea from very cool


### PR DESCRIPTION
```
$ bundle exec rake lint
manifests/init.pp - ERROR: trailing whitespace found on line 122
```