### PR TITLE
feature/65 - ignore the contents in .gems after run bundle install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg/
 Gemfile.lock
 spec/fixtures/
 .vagrant/
+.gems/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Gemfile.lock
 spec/fixtures/
 .vagrant/
 .gems/
+log/


### PR DESCRIPTION
After run `bundle install`, a new folder `.gems` generated, which needn't be managed by git.
