### PR TITLE
Fix comparison of @localusers to undef for puppet3.7/ruby1.8

### DIFF
--- a/templates/opt/splunk/etc/passwd.erb
+++ b/templates/opt/splunk/etc/passwd.erb
@@ -1,6 +1,6 @@
 <%= @splunkadmin %>
-<% if @type  == 'search' and @localusers != :undef then -%>
-<%     localusers.each do |user| -%>
+<% if @type  == 'search' and @localusers then -%>
+<%     @localusers.each do |user| -%>
 <%= user %>
 <%     end -%>
 <% end -%>


### PR DESCRIPTION
Catalog compilation fails with puppet 3.7 on ruby 1.8 (centos6) with
error calling .each on undef, due to failing comparison of @localusers
to :undef. Replace with a simple truthyness test of @localusers.

Fixes error like:
```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template splunk/opt/splunk/etc/passwd.erb:
  Filepath: /home/puppet/environments/live/modules/splunk/templates/opt/splunk/etc/passwd.erb
  Line: 3
  Detail: undefined method `each' for :undef:Symbol
 at /home/puppet/environments/live/modules/splunk/manifests/install.pp:60 on node losplaggr1.intra.gsacapital.com
Warning: Not using cache on failed catalog
Error: Could not retrieve catalog; skipping run
```