### PR TITLE
Stop managing etc/auth dir contents

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -58,16 +58,5 @@ class splunk::install (
     group   => 'root',
     backup  => true,
     content => template('splunk/opt/splunk/etc/passwd.erb'),
-  } ->
-
-  # recursively copy the contents of the auth dir
-  # This is causing a restart on the second run. - TODO
-  file { "${splunkhome}/etc/auth":
-      mode    => '0600',
-      owner   => 'splunk',
-      group   => 'splunk',
-      recurse => true,
-      purge   => false,
-      source  => 'puppet:///modules/splunk/noarch/opt/splunk/etc/auth',
   }
 }


### PR DESCRIPTION
Stop managing etc/auth dir contents

The current release installs a directory full of expired certificates into
etc/auth. This breaks the kvstore on the search/indexer machines, because
mongodb won't start with an expired cert.
Additionally, splunk seems to regenerate at least some of these certificates
when starting up, leading puppet to fight splunk over the contents and
frequent service restarts.

I can't see a good reason for this module to be managing the contents of the
certificate files; a job best left to the profile or glue module that uses
this splunk module, therefore I've removed it entirely.