### PR TITLE
Modularise inputs_hash so we can declare them from more than one place!

### DIFF
--- a/manifests/inputs.pp
+++ b/manifests/inputs.pp
@@ -1,48 +1,25 @@
-# splunk::inputs should be called  to manage your splunk inputs.conf
-# by default outputs.conf will be placed in $splunkhome/etc/system/local/
+# splunk::inputs should be called to start management your splunk inputs.conf.
+# By default inputs.conf will be placed in $splunkhome/etc/system/local/
+# To add entries to the file, use splunk::inputs::create
+#
 # === Parameters
+# $path allows you to override the default location of inputs.conf
 #
-# [input_hash]
-#   Nested Hash used to define monitored inputs. Sorry, I couldn't think of
-#   a better way to do this :/
-#   The format is:
-#   { 'input title' => { 'setting' => 'value' } }
-#
-# class { 'splunk::inputs':
-#   input_hash   => { 'script://./bin/sshdChecker.sh' => {
-#                       disabled   => 'true',
-#                       index      => 'os',
-#                       interval   => '3600',
-#                       source     => 'Unix:SSHDConfig',
-#                       sourcetype => 'Unix:SSHDConfig'},
-#                     'script://./bin/sshdChecker.sh2' => {
-#                       disabled   => 'true2',
-#                       index      => 'os2',
-#                       interval   => '36002',
-#                       source     => 'Unix:SSHDConfig2',
-#                       sourcetype => 'Unix:SSHDConfig2'}
-#                   }
-#  }
-#
-class splunk::inputs (
-  $path         = "${::splunk::splunkhome}/etc/system/local",
-  $input_hash   = { }
-  ) {
-  # Validate hash
-  if ( $input_hash ) {
-    if !is_hash($input_hash){
-      fail("${input_hash} is not a valid hash")
-    }
-  }
-  $input_title = keys($input_hash)
+class splunk::inputs ($path = "${::splunk::splunkhome}/etc/system/local") {
 
-  file { "${path}/inputs.conf":
-    ensure  => file,
+  concat {"${path}/inputs.conf":
     owner   => 'splunk',
     group   => 'splunk',
     mode    => '0644',
     require => Class['splunk::install'],
-    notify  => Class['splunk::service'],
+    notify  => Class['splunk::service']
+  }
+
+  concat::fragment {"Inputs ${name} (Default + FQDN)":
+    target  => "${path}/inputs.conf",
+    order   => '00',
     content => template('splunk/opt/splunk/etc/system/local/inputs.conf.erb'),
+    require => Class['splunk::install'],
+    notify  => Class['splunk::service']
   }
 }

--- a/manifests/inputs/create.pp
+++ b/manifests/inputs/create.pp
@@ -1,0 +1,45 @@
+# splunk::inputs::create allows you to register new inputs.
+#
+# === Parameters
+#- The resource name is used as the input title in inputs.conf
+#- $content should be a hash containing what you want to apply to the input
+#- $order is optional, it allows you to set input position in the resulting file
+#- $path functions the same it does in splunk::inputs.
+#
+# === Example
+#- Puppet code
+# ::splunk::inputs::create {'script://./bin/sshdChecker.sh':
+#   $content => {
+#     disabled   => 'true',
+#     index      => 'os',
+#     interval   => '3600',
+#     source     => 'Unix:SSHDConfig',
+#     sourcetype => 'Unix:SSHDConfig'
+#   }
+# }
+#
+#- Resulting input config
+# [script://./bin/sshdChecker.sh]
+#   disabled = true
+#   index = os
+#   interval = 3600
+#   source = Unix:SSHDConfig
+#   sourcetype = Unix:SSHDConfig
+#
+define splunk::inputs::create(
+  $content,
+  $order   = '10',
+  $path    = "${::splunk::splunkhome}/etc/system/local"
+) {
+  # Validate hash
+  if !is_hash($content){
+    fail("${content} is not a valid hash")
+  }
+
+  concat::fragment {"Inputs ${name}":
+    target  => "${path}/inputs.conf",
+    order   => $order,
+    content => template('splunk/opt/splunk/etc/system/local/inputs_create.erb'),
+    notify  => Class['splunk::service']
+  }
+}

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
   "description": "This Module manages Splunk Indexer, Search Heads, SLF and Heavy Forwarders as well as a number of apps",
   "dependencies": [
     {"name":"puppetlabs/inifile","version_requirement":">=1.0.0"},
-    {"name":"puppetlabs/stdlib","version_requirement":">=3.2.0"}
+    {"name":"puppetlabs/stdlib","version_requirement":">=3.2.0"},
+    {"name":"puppetlabs/concat","version_requirement":"=1.2.2"}
   ],
   "operatingsystem_support": [
   {

--- a/templates/opt/splunk/etc/system/local/inputs.conf.erb
+++ b/templates/opt/splunk/etc/system/local/inputs.conf.erb
@@ -4,10 +4,3 @@
 [default]
 host = <%= @fqdn %>
 
-<% @input_title.sort.each do |inputname| -%>
-[<%= inputname -%>]
-  <% @input_hash[inputname].sort.each do |key,value| -%>
-  <%= key -%> = <%= value %>
-  <% end %>
-<% end %>
-

--- a/templates/opt/splunk/etc/system/local/inputs_create.erb
+++ b/templates/opt/splunk/etc/system/local/inputs_create.erb
@@ -1,0 +1,4 @@
+[<%= name -%>]
+<% @content.sort.each do |key,value| -%>
+  <%= key -%> = <%= value %>
+<% end %>


### PR DESCRIPTION
This change moves away from the single-declaration inputs_hash, allowing us to define each input individually. It uses puppetlabs-concat to do it.

Old Style:
```puppet
# To initialise and add all inputs. Can only be declared once.
class {'::splunk::inputs':
  input_hash => {
    'monitor:///var/log/httpd/*error.log' => {
      disabled   => false,
      followTail => '0',
      sourcetype => 'apache_error',
      index      => 'myindex'
    }
  }
}
```

New Style:
```puppet
# To initialise. Can only be declared once.
class {'::splunk::inputs':}

# To add an input. Can be declared multiple times!
::splunk::inputs::create {'monitor:///var/log/httpd/*error.log':
  content => {
    disabled   => false,
    followTail => '0',
    sourcetype => 'apache_error',
    index      => 'myindex'
  }
}