### PR TITLE
Allow multiple receiving server for a target_group

### DIFF
--- a/spec/classes/splunk_ouputs_indexandforward_spec.rb
+++ b/spec/classes/splunk_ouputs_indexandforward_spec.rb
@@ -30,5 +30,39 @@ describe 'splunk::outputs', :type => :class do
       it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/server = server1.example.com:50514/) }
       it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/indexAndForward = True/) }
     end
+    describe "with multiple servers in target group" do
+      let(:params) { {
+        :configure_outputs => true,
+        :indexandforward   => true,
+        :port              => '50514',
+        :path              => '/opt/splunk/etc/system/local',
+        :output_hash       => { },
+        :target_group      => { "example1" => ["server1.example.com","server2.example.com"] }
+      } }
+
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/[tcpout]/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/defaultGroup = example1/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/disabled = false/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/tcpout:example1/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/server = server1.example.com:50514,server2.example.com:50514/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/indexAndForward = True/) }
+    end
+    describe "with an Array of server in target group" do
+      let(:params) { {
+        :configure_outputs => true,
+        :indexandforward   => true,
+        :port              => '50514',
+        :path              => '/opt/splunk/etc/system/local',
+        :output_hash       => { },
+        :target_group      => { "example1" => ["server1.example.com"] }
+      } }
+
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/[tcpout]/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/defaultGroup = example1/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/disabled = false/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/tcpout:example1/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/server = server1.example.com:50514/) }
+      it { should contain_file('/opt/splunk/etc/system/local/outputs.conf').with_content(/indexAndForward = True/) }
+    end
   end
 end

--- a/templates/opt/splunk/etc/system/local/outputs.conf.erb
+++ b/templates/opt/splunk/etc/system/local/outputs.conf.erb
@@ -6,8 +6,11 @@ disabled = <%= @tcpout_disabled %>
 
 <% @groupkeys.sort.each do |group| -%>
 [tcpout:<%= group -%>]
+<% if @target_group[group].is_a?(Array) -%>
+server = <%= @target_group[group].map { |server| "#{server}:#{@port}"}.join(',') %>
+<% else -%>
 server = <%= @target_group[group] -%>:<%= @port %>
-
+<% end -%>
 <% end -%>
 <% end -%>
 <% if @indexandforward == true || @indexandforward == 'true' || @indexandforward == 'True' -%>


### PR DESCRIPTION
This code update will allow a forwarder output.conf to have multiple
receiving servers for a particular target group. This is usually use for
load-balancing purpose (http://docs.splunk.com/Documentation/Splunk/3.1.3/Admin/SetUpDataBalancing)

2 rspec are included to make sure the expected behavior.