### PR TITLE
Allow override of certificate management for flexibility and security

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,6 +120,7 @@ class splunk (
   $package_provider  = undef,
   $version           = $::splunk::params::version,
   $replace_passwd    = $::splunk::params::replace_passwd,
+  $manage_certs      = $::splunk::params::manage_certs
 ) inherits splunk::params {
 
 # Added the preseed hack after getting the idea from very cool

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,7 +8,8 @@ class splunk::install (
   $version          = $::splunk::version,
   $package_source   = $::splunk::package_source,
   $package_provider = $::splunk::package_provider,
-  $replace_passwd   = $::splunk::replace_passwd
+  $replace_passwd   = $::splunk::replace_passwd,
+  $manage_certs     = $::splunk::manage_certs
   ) {
 
   package { $pkgname:
@@ -62,12 +63,14 @@ class splunk::install (
 
   # recursively copy the contents of the auth dir
   # This is causing a restart on the second run. - TODO
-  file { "${splunkhome}/etc/auth":
-      mode    => '0600',
-      owner   => 'splunk',
-      group   => 'splunk',
-      recurse => true,
-      purge   => false,
-      source  => 'puppet:///modules/splunk/noarch/opt/splunk/etc/auth',
+  if $manage_certs {
+    file { "${splunkhome}/etc/auth":
+        mode    => '0600',
+        owner   => 'splunk',
+        group   => 'splunk',
+        recurse => true,
+        purge   => false,
+        source  => 'puppet:///modules/splunk/noarch/opt/splunk/etc/auth',
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,6 +14,7 @@ class splunk::params {
   $purge             = undef
   $version           = 'installed'
   $replace_passwd    = 'no'
+  $manage_certs      = true
 
   if $::mode == maintenance {
     $service_ensure = 'stopped'


### PR DESCRIPTION
Allowing users to override certificate management enables them to use custom certificates as well as not have to store private keys in their module repositories.

The default behavior is retained in this PR as the default value is true.