### PR TITLE
Updated CHANGELOG and fixing broken tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,14 +9,17 @@ rvm:
   - 2.0.0
 bundler_args: --without system_tests
 env:
-  matrix:
+  - PUPPET_VERSION=4.4.1
   - PUPPET_VERSION=3.7.3
   - PUPPET_VERSION=3.6.0
-  - PUPPET_VERSION=3.5.0
+  - PUPPET_VERSION=3.5.1
   - PUPPET_VERSION=3.4.2
   - PUPPET_VERSION=3.3.1
   - PUPPET_VERSION=3.2.3
   - PUPPET_VERSION=2.7.21
-  global:
-  - PUBLISHER_LOGIN=huit
-  - secure: Ijc9NOKcofDC+i0afauvFj7P6vqtThbeMnjuOYxaqcMPfM4f+IrxpzyoIjOzDbD83b0vMYCSItPW/RExVINkwhjghfzPhMsbjfA2XfcvWYMxCOsvXR3TMHSNyPGD7ITbitUDofJ0TTIfZQwE10SeI8MhfL61a4eiR2QNQhDyraI=
+matrix:
+  exclude:
+   - rvm: 1.8.7
+     env: PUPPET_VERSION=4.4.1
+   - rvm: 2.0.0
+     env: PUPPET_VERSION=2.7.21

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+1.7.2 - Ben Roberts <me@benroberts.net> 
+  * Fix comparison of @localusers to undef for puppet3.7/ruby1.8
 1.7.1 - Tim Hartmann <tfhartmann@gmail.com> 
   * Fixes issue #54 by adding configure_outputs parameter
 1.7.0 - Joe Eaves <jinux@alluha.net>, Tim Hartmann <tfhartmann@gmail.com> 

--- a/Gemfile
+++ b/Gemfile
@@ -1,19 +1,28 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rake',                    :require => false
-  gem 'rspec-core', '3.1.7',     :require => false
   gem 'rspec-puppet',            :require => false
   gem 'puppetlabs_spec_helper',  :require => false
   gem 'puppet-lint',             :require => false
   gem 'simplecov',               :require => false
   gem 'puppet_facts',            :require => false
   gem 'json',                    :require => false
+  gem 'iconv',                   :require => false
 end
 
 group :system_tests do
   gem 'beaker-rspec',  :require => false
   gem 'serverspec',    :require => false
+end
+
+if rubyversion = `ruby --version`
+  if rubyversion =~ /1.8.7/
+    gem 'rake',       '10.3.2',    :require => false
+    gem 'rspec-core', '2.99.2',    :require => false
+  end 
+else
+  gem 'rake',                  :require => false
+  gem 'rspec-core', '3.1.7',   :require => false
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']
@@ -22,7 +31,7 @@ else
   gem 'facter', :require => false
 end
 
-if puppetversion = ENV['PUPPET_GEM_VERSION']
+if puppetversion = ENV['PUPPET_VERSION']
   gem 'puppet', puppetversion, :require => false
 else
   gem 'puppet', :require => false

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -108,7 +108,7 @@ class splunk (
   $localusers        = $::splunk::params::localusers,
   $licenseserver     = undef,
   $nagios_contacts   = $::splunk::params::nagios_contacts,
-  $nagiosserver      = $::splunk::nagiosserver,
+  $nagiosserver      = undef,
   $output_hash       = $::splunk::params::output_hash,
   $port              = $::splunk::params::port,
   $proxyserver       = $::splunk::params::proxyserver,


### PR DESCRIPTION
Tests started throwing this error with Puppet 4.4.1

```Ruby
  1) splunk on RedHat platform Splunk class with no parameters, basic
  test should compile into a catalogue without dependency cycles
       Failure/Error: should compile
              error during compilation: Evaluation Error: Error while
              evaluating a Function Call, default expression for
              $nagiosserver tries to illegally access not yet evaluated
              $nagiosserver at line 1:1 on node preator.local
                   # ./spec/classes/splunk_spec.rb:8:in `block (4
                   # levels) in <top (required)>'

```

Adding Puppet 4.4.1 to travis tests

Fix to Gemfile to insall gems on ruby 1.8.7

Don't judge me....

Test

So ghetto

Maybe set the right var name huh?

Excluding Puppet 4x from Ruby 1.8.7

Travis updates

Adding iconv gem

Trying to address this error during the Puppet 2.7 test

```
iconv couldn't be loaded, which is required for UTF-8/UTF-16 conversions
rake aborted!
```

Removing tests on 2.7 for Ruby 2.x