### PR TITLE
Remove unecessary require which breaks puppet4 compatibility

### DIFF
--- a/manifests/deploymentclient.pp
+++ b/manifests/deploymentclient.pp
@@ -14,7 +14,6 @@ class splunk::deploymentclient (
   $path              = "${::splunk::splunkhome}/etc/system/local",
   $targeturi         = undef
   ) {
-  Class{ require => Class['splunk::install'] }
 
   # Validate string
   if !$targeturi {


### PR DESCRIPTION
From what I can tell this require in splunk::deploymentclient has no practical effect, since there are no other classes instantiated in this class, and yet it breaks the puppet 4 parser. I propose to remove it. This compiles cleanly under puppetserver 2.4.0.