### PR TITLE
Removed timeout parameter from Fact.add

### DIFF
--- a/lib/facter/splunk_version.rb
+++ b/lib/facter/splunk_version.rb
@@ -1,5 +1,5 @@
 require 'find'
-Facter.add(:splunk_version, :timeout => 30) do
+Facter.add(:splunk_version) do
   confine :kernel => :linux
   setcode do
     command = ''


### PR DESCRIPTION
The timeout parameter was causing a warning because it is not a supported parameter for custom facts.

Warning: Facter: timeout option is not supported for custom facts and will be ignored.

This issue was noticed in agent version puppet-agent-1.10.1-1.el7.x86_64.